### PR TITLE
Set consent withdrawn correctly in messages dataset

### DIFF
--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -55,8 +55,13 @@ class ConsentUtils(object):
         :param withdrawn_key: Name of key to use for the consent withdrawn field.
         :type withdrawn_key: str
         """
+        stopped_uids = set()
         for td in data:
             if cls.td_has_stop_code(td, coding_plans):
+                stopped_uids.add(td["uid"])
+
+        for td in data:
+            if td["uid"] in stopped_uids:
                 td.append_data(
                     {withdrawn_key: Codes.TRUE},
                     Metadata(user, Metadata.get_call_location(), time.time())


### PR DESCRIPTION
Corrects a problem where, if a participant opted-out, and their opt out message landed only in an rqa field (not a demog field, which we’d normally expect them to end up in), and they sent multiple RQA messages, only one of their messages would have consent_withdrawn: true in the messages dataset.